### PR TITLE
76 tokenizer preamble

### DIFF
--- a/src/main/java/seedu/logjob/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/logjob/logic/parser/AddCommandParser.java
@@ -4,8 +4,6 @@ import static seedu.logjob.logic.parser.CliSyntax.FLAG_COMPANY_NAME;
 import static seedu.logjob.logic.parser.CliSyntax.FLAG_JOB_TITLE;
 import static seedu.logjob.logic.parser.CliSyntax.FLAG_APPLICATION_DATE;
 import static seedu.logjob.logic.parser.CliSyntax.FLAG_APPLICATION_STATUS;
-import static seedu.logjob.logic.parser.ParserUtil.containsAllFlags;
-import static seedu.logjob.logic.parser.ParserUtil.containsNoDuplicateFlags;
 import static seedu.logjob.model.ApplicationStatus.APPLIED;
 
 import java.time.LocalDate;
@@ -18,6 +16,12 @@ import seedu.logjob.model.ApplicationStatus;
  * Parses input arguments and creates a new {@code AddCommand} Object
  */
 public class AddCommandParser implements Parser<AddCommand> {
+    private static final Flag[] MANDATORY_FLAGS = {
+        FLAG_COMPANY_NAME, FLAG_JOB_TITLE
+    };
+    private static final Flag[] ADD_FLAGS = {
+        FLAG_COMPANY_NAME, FLAG_JOB_TITLE, FLAG_APPLICATION_DATE, FLAG_APPLICATION_STATUS
+    };
 
     /**
      * Parses input arguments string and returns an {@code AddCommand} object.
@@ -29,13 +33,19 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     @Override
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMap argMap =
-                ArgumentTokenizer.tokenize(
-                        args, FLAG_COMPANY_NAME, FLAG_JOB_TITLE, FLAG_APPLICATION_DATE, FLAG_APPLICATION_STATUS);
+        ArgumentMap argMap = ArgumentTokenizer.tokenize(args, ADD_FLAGS);
 
-        containsAllFlags(argMap, FLAG_COMPANY_NAME, FLAG_JOB_TITLE);
-        containsNoDuplicateFlags(
-                argMap, FLAG_COMPANY_NAME, FLAG_JOB_TITLE, FLAG_APPLICATION_DATE, FLAG_APPLICATION_STATUS);
+        if (argMap.missingFlags(MANDATORY_FLAGS)) {
+            throw new ParseException("Missing flag(s): " + argMap.getMissingFlags(MANDATORY_FLAGS));
+        }
+
+        if (!argMap.getPreamble().trim().isEmpty()) {
+            throw new ParseException("Add command has no preamble:" + argMap.getPreamble());
+        }
+
+        if (argMap.containsDuplicateFlags(ADD_FLAGS)) {
+            throw new ParseException("Duplicate flag(s): " + argMap.getDuplicateFlags(ADD_FLAGS));
+        }
 
         String companyName = ParserUtil.parseCompanyName(argMap.get(FLAG_COMPANY_NAME));
         String jobTitle = ParserUtil.parseJobTitle(argMap.get(FLAG_JOB_TITLE));

--- a/src/main/java/seedu/logjob/logic/parser/ArgumentMap.java
+++ b/src/main/java/seedu/logjob/logic/parser/ArgumentMap.java
@@ -1,8 +1,11 @@
 package seedu.logjob.logic.parser;
 
+import seedu.logjob.logic.parser.exceptions.ParseException;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * A map structure that stores multiple values for a single {@code Flag} key.
@@ -52,7 +55,7 @@ public class ArgumentMap {
      * @param key the flag to check
      * @return true if multiple values exist, false otherwise
      */
-    public boolean containsMultipleValues(Flag key) {
+    private boolean containsMultipleValues(Flag key) {
         return multiMap.containsKey(key) && multiMap.get(key).size() > 1;
     }
 
@@ -74,4 +77,30 @@ public class ArgumentMap {
     public int size() {
         return multiMap.size();
     }
+
+    /**
+     * Validates multimap to contain all input flags
+     */
+    public boolean containsAllFlags(Flag... flags) {
+        return validateFlags(flag -> !containsKey(flag), flags);
+    }
+
+    /**
+     * Validates argument map to contain no duplicate flags
+     * @throws ParseException Lists all duplicate flags
+     */
+    public boolean containsNoDuplicateFlags(Flag... flags) {
+        return validateFlags(this::containsMultipleValues, flags);
+    }
+
+    private boolean validateFlags(Predicate<Flag> condition,
+                                      Flag... flags){
+        for (Flag flag : flags) {
+            if (condition.test(flag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/seedu/logjob/logic/parser/ArgumentMap.java
+++ b/src/main/java/seedu/logjob/logic/parser/ArgumentMap.java
@@ -9,6 +9,11 @@ import java.util.List;
  */
 public class ArgumentMap {
     private final HashMap<Flag, List<String>> multiMap = new HashMap<>();
+    private final String preamble;
+
+    public ArgumentMap(String preamble) {
+        this.preamble = preamble;
+    }
 
     /**
      * Adds a value to the list associated with the given flag.
@@ -49,6 +54,10 @@ public class ArgumentMap {
      */
     public boolean containsMultipleValues(Flag key) {
         return multiMap.containsKey(key) && multiMap.get(key).size() > 1;
+    }
+
+    public String getPreamble() {
+        return this.preamble;
     }
 
     /**

--- a/src/main/java/seedu/logjob/logic/parser/ArgumentMap.java
+++ b/src/main/java/seedu/logjob/logic/parser/ArgumentMap.java
@@ -1,6 +1,5 @@
 package seedu.logjob.logic.parser;
 
-import seedu.logjob.logic.parser.exceptions.ParseException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -81,26 +80,42 @@ public class ArgumentMap {
     /**
      * Validates multimap to contain all input flags
      */
-    public boolean containsAllFlags(Flag... flags) {
-        return validateFlags(flag -> !containsKey(flag), flags);
+    public boolean missingFlags(Flag[] flags) {
+        return anyFlagFails(flag -> !containsKey(flag), flags);
     }
 
     /**
      * Validates argument map to contain no duplicate flags
-     * @throws ParseException Lists all duplicate flags
      */
-    public boolean containsNoDuplicateFlags(Flag... flags) {
-        return validateFlags(this::containsMultipleValues, flags);
+    public boolean containsDuplicateFlags(Flag[] flags) {
+        return anyFlagFails(flag -> containsMultipleValues(flag), flags);
     }
 
-    private boolean validateFlags(Predicate<Flag> condition,
-                                      Flag... flags){
+    private boolean anyFlagFails(Predicate<Flag> condition, Flag... flags){
         for (Flag flag : flags) {
             if (condition.test(flag)) {
                 return true;
             }
         }
         return false;
+    }
+
+    public String getMissingFlags(Flag[] flags) {
+        return accumulateFlags(flag -> !containsKey(flag), flags);
+    }
+
+    public String getDuplicateFlags(Flag[] flags) {
+        return accumulateFlags(flag -> containsMultipleValues(flag), flags);
+    }
+
+    private String accumulateFlags(Predicate<Flag> condition, Flag[] flags) {
+        StringBuilder accumulatedFlags = new StringBuilder();
+        for (Flag flag : flags) {
+            if (condition.test(flag)) {
+                accumulatedFlags.append(flag.flag()).append(" ");
+            }
+        }
+        return accumulatedFlags.toString();
     }
 
 }

--- a/src/main/java/seedu/logjob/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/logjob/logic/parser/ArgumentTokenizer.java
@@ -56,8 +56,15 @@ public class ArgumentTokenizer {
 
 
     private static ArgumentMap extractArguments(String arguments, List<FlagPosition> flagPositions) {
-        ArgumentMap argumentMap = new ArgumentMap();
         flagPositions.sort(Comparator.comparingInt(FlagPosition::startIndex));
+
+        // Parse Preamble
+        String preamble = arguments;
+        if (!flagPositions.isEmpty()) {
+            FlagPosition first = flagPositions.get(0);
+            preamble = arguments.substring(0, first.startIndex());
+        }
+        ArgumentMap argumentMap = new ArgumentMap(preamble);
 
         // Dummy end position to represent end of the String
         FlagPosition endPositionMarker = new FlagPosition(new Flag(""), arguments.length());
@@ -67,7 +74,6 @@ public class ArgumentTokenizer {
             FlagPosition currPosition = flagPositions.get(i);
             FlagPosition nextPosition = flagPositions.get(i + 1);
             String argumentValue = getArgumentValue(arguments, currPosition, nextPosition);
-
             argumentMap.put(currPosition.flag(), argumentValue);
         }
 

--- a/src/main/java/seedu/logjob/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/logjob/logic/parser/EditCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.logjob.logic.parser;
 
-import static seedu.logjob.logic.parser.CliSyntax.FLAG_APPLICATION_INDEX;
 import static seedu.logjob.logic.parser.CliSyntax.FLAG_COMPANY_NAME;
 import static seedu.logjob.logic.parser.CliSyntax.FLAG_JOB_TITLE;
 import static seedu.logjob.logic.parser.CliSyntax.FLAG_APPLICATION_DATE;
@@ -16,22 +15,28 @@ import seedu.logjob.model.ApplicationStatus;
 import java.time.LocalDate;
 
 public class EditCommandParser implements Parser<EditCommand>{
+    private static final Flag[] EDIT_FLAGS = {
+        FLAG_COMPANY_NAME, FLAG_JOB_TITLE, FLAG_APPLICATION_DATE, FLAG_APPLICATION_STATUS
+    };
 
     @Override
     public EditCommand parse(String args) throws ParseException {
-        ArgumentMap argMap = ArgumentTokenizer.tokenize(args, FLAG_APPLICATION_INDEX, FLAG_COMPANY_NAME,
-                FLAG_JOB_TITLE, FLAG_APPLICATION_DATE, FLAG_APPLICATION_STATUS);
+        ArgumentMap argMap = ArgumentTokenizer.tokenize(args, EDIT_FLAGS);
 
         // Parse index to be edited
-        ParserUtil.containsAllFlags(argMap, FLAG_APPLICATION_INDEX);
-        int editIndex = ParserUtil.parseJobApplicationIndex(argMap.get(FLAG_APPLICATION_INDEX));
+        String editIndexString = argMap.getPreamble().trim();
+        if (editIndexString.isEmpty()) {
+            throw new ParseException("Edit command requires an index.");
+        }
+        int editIndex = ParserUtil.parseJobApplicationIndex(editIndexString);
 
         // Parse fields to be edited
-        if (argMap.size() <= 1) { // Only contains Index flag
+        if (argMap.isEmpty()) {
             throw new ParseException("Edit command requires at least one argument.");
         }
-        ParserUtil.containsNoDuplicateFlags(argMap, FLAG_APPLICATION_INDEX, FLAG_COMPANY_NAME
-                , FLAG_JOB_TITLE, FLAG_APPLICATION_DATE, FLAG_APPLICATION_STATUS);
+        if (argMap.containsDuplicateFlags(EDIT_FLAGS)) {
+            throw new ParseException("Duplicate flag(s): " + argMap.getDuplicateFlags(EDIT_FLAGS));
+        }
         String companyName = null;
         String jobTitle = null;
         LocalDate applicationDate = null;

--- a/src/main/java/seedu/logjob/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/logjob/logic/parser/ParserUtil.java
@@ -79,37 +79,4 @@ public class ParserUtil {
         }
     }
 
-    /**
-     * Validates argument map to contain all input flags
-     * @throws ParseException Lists all missing flags
-     */
-    public static void containsAllFlags(ArgumentMap argMap, Flag... flags)
-            throws ParseException {
-        validateFlags(flag -> !argMap.containsKey(flag),
-                "Missing flag(s): ", flags);
-    }
-
-    /**
-     * Validates argument map to contain no duplicate flags
-     * @throws ParseException Lists all duplicate flags
-     */
-    public static void containsNoDuplicateFlags(ArgumentMap argMap, Flag... flags)
-            throws ParseException {
-        validateFlags(argMap::containsMultipleValues,
-                "Duplicate flag(s): ", flags);
-    }
-
-    private static void validateFlags(Predicate<Flag> condition,
-                                      String errorMessagePrefix,
-                                      Flag... flags) throws ParseException {
-        StringBuilder errorMessage = new StringBuilder();
-        for (Flag flag : flags) {
-            if (condition.test(flag)) {
-                errorMessage.append(flag.toString()).append(" ");
-            }
-        }
-        if (!errorMessage.isEmpty()) {
-            throw new ParseException(errorMessagePrefix + errorMessage);
-        }
-    }
 }

--- a/src/main/java/seedu/logjob/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/logjob/logic/parser/ParserUtil.java
@@ -10,7 +10,6 @@ import seedu.logjob.logic.validator.ApplicationStatusValidator;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
-import java.util.function.Predicate;
 
 
 /**

--- a/src/test/java/seedu/logjob/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/logjob/logic/parser/AddCommandParserTest.java
@@ -29,7 +29,7 @@ public class AddCommandParserTest {
                 new AddCommand("Google", "Software Engineer", LocalDate.now(), ApplicationStatus.APPLIED));
 
         // Args contain special Characters
-        assertParseSuccess(parser, " -s 3 -j C++ Software Engineer -n JPMorgan Chase & Co",
+        assertParseSuccess(parser, "      -s 3 -j C++ Software Engineer -n JPMorgan Chase & Co",
                 new AddCommand("JPMorgan Chase & Co",
                         "C++ Software Engineer", LocalDate.now(),
                         ApplicationStatus.OFFERED));
@@ -50,6 +50,12 @@ public class AddCommandParserTest {
                 "Missing flag(s): -n ");
         assertParseFailure(parser, " -j Software Engineer -j AI/ML Engineer",
                 "Missing flag(s): -n ");
+
+        // contains preamble
+        assertParseFailure(parser, " this job -j Software Engineer -n TechCompany",
+                "Add command has no preamble: this job ");
+        assertParseFailure(parser, " Hello Hello -j AI/ML Engineer -j Test Engineer -n Bing",
+                "Add command has no preamble: Hello Hello ");
 
         // single duplicate flag
         assertParseFailure(parser, " -n Yahoo -n Bing -j Software Engineer",

--- a/src/test/java/seedu/logjob/logic/parser/ApplicationParserTest.java
+++ b/src/test/java/seedu/logjob/logic/parser/ApplicationParserTest.java
@@ -60,7 +60,7 @@ public class ApplicationParserTest {
 
     @Test
     public void parseCommand_validEditCommand_returnsEditCommand() throws Exception {
-        Command result = parser.parseCommand("edit -i 1 -s 1 ");
+        Command result = parser.parseCommand("edit 1 -s 1 ");
         assertInstanceOf(EditCommand.class, result);
     }
 

--- a/src/test/java/seedu/logjob/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/logjob/logic/parser/EditCommandParserTest.java
@@ -17,21 +17,21 @@ public class EditCommandParserTest {
     @Test
     void parse_validArgs_returnsEditCommand() throws ParseException {
         // One Edit field
-        assertParseSuccess(parser, " -i 1 -n Google",
+        assertParseSuccess(parser, " 1 -n Google",
                 new EditCommand(1, "Google", null, null, null));
 
         // Multiple Edit Fields
-        assertParseSuccess(parser, " -s 1 -j Software Engineer -n Google -i 2",
+        assertParseSuccess(parser, " 2 -j Software Engineer -s 1 -n Google ",
                 new EditCommand(2, "Google", "Software Engineer",
                         null, ApplicationStatus.INTERVIEW));
 
         // All fields edited
-        assertParseSuccess(parser, " -i 003 -j Software Engineer -n Google -s 3 -d 2025-03-25",
+        assertParseSuccess(parser, " 003 -j Software Engineer -n Google -s 3 -d 2025-03-25",
                 new EditCommand(3,"Google", "Software Engineer",
                         LocalDate.of(2025,3,25),  ApplicationStatus.OFFERED));
 
         // Args contain special Characters
-        assertParseSuccess(parser, "  -i -01 -j C++ Software Engineer -n JPMorgan Chase & Co",
+        assertParseSuccess(parser, "  -01 -j C++ Software Engineer -n JPMorgan Chase & Co",
                 new EditCommand(-1, "JPMorgan Chase & Co",
                         "C++ Software Engineer", null, null));
     }
@@ -40,50 +40,52 @@ public class EditCommandParserTest {
     void parse_invalidArgs_throwsParseException() {
         // Contains no edit index
         assertParseFailure(parser, "",
-                "Missing flag(s): -i ");
+                "Edit command requires an index.");
+        assertParseFailure(parser, " -j JobTitle",
+                "Edit command requires an index.");
         assertParseFailure(parser, "       ",
-                "Missing flag(s): -i ");
+                "Edit command requires an index.");
 
         // Contains non-numeric index
-        assertParseFailure(parser, " -i abc -j JobTitle ",
+        assertParseFailure(parser, " abc -j JobTitle ",
                 "Job Application Index must be numeric: abc");
-        assertParseFailure(parser, " -n Bing -i #1",
+        assertParseFailure(parser, " #1 -n CompanyName ",
                 "Job Application Index must be numeric: #1");
-        assertParseFailure(parser, " -i 1 invalid -n Yahoo ",
+        assertParseFailure(parser, " 1 invalid -n CompanyName ",
                 "Job Application Index must be numeric: 1 invalid");
 
         // Contains no edit fields (only has index)
-        assertParseFailure(parser, " -i 0    ",
+        assertParseFailure(parser, "    0",
                 "Edit command requires at least one argument.");
-        assertParseFailure(parser, "    -i 123 ",
+        assertParseFailure(parser, "    -123 ",
                 "Edit command requires at least one argument.");
 
         // Contains duplicate fields
-        assertParseFailure(parser, " -i 0 -i 1 -n Yahoo",
-                "Duplicate flag(s): -i ");
-        assertParseFailure(parser, " -i 0 -n CompanyName -i 1 -n CompanyName -j  JobTitle",
-                "Duplicate flag(s): -i -n ");
+        assertParseFailure(parser, " 0 -s 1 -n CompanyName -s APPLIED",
+                "Duplicate flag(s): -s ");
+        assertParseFailure(parser, " 1 -s 3 -n CompanyName -s INTERVIEW -n CompanyName -j  JobTitle",
+                "Duplicate flag(s): -n -s ");
 
         // Invalid argument: Company Name
-        assertParseFailure(parser, " -i 0 -n    -j Software Engineer" ,
+        assertParseFailure(parser, " 0 -n    -j Software Engineer" ,
                 "Invalid Company Name: ");
-        assertParseFailure(parser, " -n *Invalid Company -i 1 -j Software Engineer" ,
+        assertParseFailure(parser, " 1 -n *Invalid Company   -j Software Engineer" ,
                 "Invalid Company Name: *Invalid Company");
 
         // Invalid argument: Job Title
-        assertParseFailure(parser, " -n Google -j -i -1" ,
+        assertParseFailure(parser, " 3 -n Google -j" ,
                 "Invalid Job Title: ");
-        assertParseFailure(parser, " -n Google -j  |Invalid Job Title| -i 0",
+        assertParseFailure(parser, " 4 -n Google -j  |Invalid Job Title| ",
                 "Invalid Job Title: |Invalid Job Title|");
 
         // Invalid argument: Application Status
-        assertParseFailure(parser, " -s -n Bing -i 0 -j Software Engineer",
+        assertParseFailure(parser, " 5 -s -n Bing -j Software Engineer",
                 "Invalid Application Status: ");
-        assertParseFailure(parser, " -i 1 -n Bing -j Software Engineer -s I've Applied!",
+        assertParseFailure(parser, " 6  -n Bing -j Software Engineer -s I've Applied!",
                 "Invalid Application Status: I've Applied!");
-        assertParseFailure(parser, " -s 6 -n Bing -j Software Engineer   -i 2",
+        assertParseFailure(parser, " 7 -s    6 -n Bing -j Software Engineer   ",
                 "Invalid Application Status: 6");
-        assertParseFailure(parser, " -s -1 -i 3 -n Bing -j Software Engineer",
+        assertParseFailure(parser, " 8   -s -1 -n Bing -j Software Engineer",
                 "Invalid Application Status: -1");
     }
 }


### PR DESCRIPTION
- Add Preamble attribute to ArgumentMap class.
- Update tokenizer to parse preamble, which is the string after the first word and before the first flag.
E.g. `add test test -j JobTitle -n CompanyName, preamble = " test test "`
`edit 0 -s Applied , preamble = " 0 "` 
- Use preamble to check for invalid strings after add command.
- User preamble to parse index of application to be edited.
- Solves bug described in #76